### PR TITLE
multiple makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,46 +9,71 @@ CRONDIR       ?= $(SYSCONFDIR)/cron.d
 LOGDIR        ?= /var/log
 
 all:
-	@echo "Nothing to compile, run make install."
+	@echo "Nothing to compile, please choose a specific target:"
+	@echo "    install (includes install-base, install-man, and install-doc)"
+	@echo "    install-base"
+	@echo "    install-man"
+	@echo "    install-doc"
+	@echo "    uninstall (includes uninstall-base, uninstall-man, and uninstall-doc)"
+	@echo "    uninstall-base"
+	@echo "    uninstall-man"
+	@echo "    uninstall-doc"
 
-install:
+src/recap.cron:
+	@sed -e 's|@BINDIR@|$(BINDIR)|' src/recap.cron.in > src/recap.cron
+
+clean:
+	@rm -f src/recap.cron
+
+install: install-base install-man install-doc
+
+uninstall: uninstall-base uninstall-man uninstall-doc
+
+install-base: src/recap.cron
 	@echo "Installing scripts..."
 	@install -Dm0755 src/recap $(DESTDIR)$(BINDIR)/recap
 	@install -Dm0755 src/recaplog $(DESTDIR)$(BINDIR)/recaplog
 	@install -Dm0755 src/recaptool $(DESTDIR)$(BINDIR)/recaptool
-	@echo "Installing man pages..."
-	@install -Dm0644 src/recap.5 $(DESTDIR)$(MANDIR)/man5/recap.5
-	@install -Dm0644 src/recap.8 $(DESTDIR)$(MANDIR)/man8/recap.8
-	@install -Dm0644 src/recaplog.8 $(DESTDIR)$(MANDIR)/man8/recaplog.8
-	@install -Dm0644 src/recaptool.8 $(DESTDIR)$(MANDIR)/man8/recaptool.8
 	@echo "Installing configuration..."
 	@install -Dm0644 src/recap.conf $(DESTDIR)$(SYSCONFDIR)/recap
 	@echo "Installing cron job..."
 	@install -Dm0644 src/recap.cron $(DESTDIR)$(CRONDIR)/recap
-	@sed -i 's,/usr/sbin/,$(BINDIR)/,' $(DESTDIR)$(CRONDIR)/recap
-	@echo "Installing docs..."
-	@install -dm0755 $(DESTDIR)$(DOCDIR)/recap
-	@install -Dm0644 CHANGELOG.md README.md COPYING -t $(DESTDIR)$(DOCDIR)/recap
 	@echo "Creating log directories..."
 	@install -dm0750 $(DESTDIR)$(LOGDIR)/recap
 	@install -dm0750 $(DESTDIR)$(LOGDIR)/recap/backups
 	@install -dm0750 $(DESTDIR)$(LOGDIR)/recap/snapshots
 
-uninstall:
+install-man:
+	@echo "Installing man pages..."
+	@install -Dm0644 src/recap.5 $(DESTDIR)$(MANDIR)/man5/recap.5
+	@install -Dm0644 src/recap.8 $(DESTDIR)$(MANDIR)/man8/recap.8
+	@install -Dm0644 src/recaplog.8 $(DESTDIR)$(MANDIR)/man8/recaplog.8
+	@install -Dm0644 src/recaptool.8 $(DESTDIR)$(MANDIR)/man8/recaptool.8
+
+install-doc:
+	@echo "Installing docs..."
+	@install -dm0755 $(DESTDIR)$(DOCDIR)/recap
+	@install -Dm0644 CHANGELOG.md README.md COPYING -t $(DESTDIR)$(DOCDIR)/recap
+
+uninstall-base:
 	@echo "Removing scripts..."
 	@rm -f $(DESTDIR)$(BINDIR)/recap
 	@rm -f $(DESTDIR)$(BINDIR)/recaplog
 	@rm -f $(DESTDIR)$(BINDIR)/recaptool
-	@echo "Removing man pages..."
-	@rm -f $(DESTDIR)$(MANDIR)/man5/recap.5
-	@rm -f $(DESTDIR)$(MANDIR)/man8/recap.8
-	@rm -f $(DESTDIR)$(MANDIR)/man8/recaplog.8
-	@rm -f $(DESTDIR)$(MANDIR)/man8/recaptool.8
-	@echo "Removing docs..."
-	@rm -Rf $(DESTDIR)$(DOCDIR)/recap
 	@echo "Removing configuration..."
 	@rm -f $(DESTDIR)$(SYSCONFDIR)/recap
 	@echo "Removing cron job..."
 	@rm -f $(DESTDIR)$(CRONDIR)/recap
 
-.PHONY: install uninstall purge
+uninstall-man:
+	@echo "Removing man pages..."
+	@rm -f $(DESTDIR)$(MANDIR)/man5/recap.5
+	@rm -f $(DESTDIR)$(MANDIR)/man8/recap.8
+	@rm -f $(DESTDIR)$(MANDIR)/man8/recaplog.8
+	@rm -f $(DESTDIR)$(MANDIR)/man8/recaptool.8
+
+uninstall-doc:
+	@echo "Removing docs..."
+	@rm -Rf $(DESTDIR)$(DOCDIR)/recap
+
+.PHONY: install install-base install-man install-doc uninstall uninstall-base uninstall-man uninstall-doc clean

--- a/src/recap.cron.in
+++ b/src/recap.cron.in
@@ -2,33 +2,32 @@
 #uncomment for the files you want saved
 
 # runs at boot, backup the last set of reports generated prior to a reboot
-@reboot root /usr/sbin/recap -B
+@reboot root @BINDIR@/recap -B
 
 #The following are examples of times to run recap
 #This file should be in /etc/cron.d
 #Only uncomment or create one active line per installation
 
 #At 2am every day
-#0 2 * * * root /usr/sbin/recap
+#0 2 * * * root @BINDIR@/recap
 
 #At 2am and 2pm every day
-#0 2,14 * * * root /usr/sbin/recap
+#0 2,14 * * * root @BINDIR@/recap
 
 #At 2am, 8am, 2pm, 8pm every day
-#0 2,8,14,20 * * * root /usr/sbin/recap
+#0 2,8,14,20 * * * root @BINDIR@/recap
 
 #Every hour
-#0 * * * * root /usr/sbin/recap
+#0 * * * * root @BINDIR@/recap
 
 #Every 30 minutes
-#*/30 * * * * root /usr/sbin/recap
+#*/30 * * * * root @BINDIR@/recap
 
 #Every 10 minutes
-*/10 * * * * root /usr/sbin/recap
+*/10 * * * * root @BINDIR@/recap
 
 #Every 5 minutes
-#*/5 * * * * root /usr/sbin/recap
+#*/5 * * * * root @BINDIR@/recap
 
 # Pack and clear log files
-0 1 * * * root /usr/sbin/recaplog
-
+0 1 * * * root @BINDIR@/recaplog

--- a/util/packaging/rpm/recap.spec
+++ b/util/packaging/rpm/recap.spec
@@ -25,7 +25,10 @@ optional reporting on Apache, MySQL, and network connections.
 
 %install
 %{__rm} -rf %{buildroot}
-PREFIX=%{_prefix} DESTDIR=%{buildroot} make install
+export PREFIX=%{_prefix}
+export DESTDIR=%{buildroot}
+make install-base
+make install-man
 
 
 %clean


### PR DESCRIPTION
In RPM spec files, putting doc files in place is handled by the %doc and
%license macros.  In other words, we need to be able to explictly install
everything _but_ the docs.  This change preserves the existing behavior of
`make install`/`make uninstall`, but splits the actions out into separate
targets.  This will allow us to only run `make install-base` and `make
install-man` in the spec file.  Additionally, this change templatizes the
recap.cron file and generates it appropriately.