### PR TITLE
Plugin Redis: Intial implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,7 @@ All notable changes to this project will be documented in this file.
 - Jay Goldberg
 - Jeffrey Ness
 - John Schwinghammer (schwing)
-- LukeHandle
+- Luke Hanley (LukeHandle)
 - Man Chung (man-chung)
 - Piers Cornwell (piersc)
 - rackerjimmy

--- a/src/plugins/redis
+++ b/src/plugins/redis
@@ -55,11 +55,13 @@ print_redis() {
   log INFO "Ended '${plugin_name}' report"
 }
 
-# Executing this functions takes ~20 seconds as each command is sampling performance in a timeframe
+# Executing this functions takes ~20 seconds as each command is sampling
+# performance in a timeframe
 print_redis_timings() {
   echo "Redis stat (+delta / 0.5s)" >> "${LOGFILE}"
-  # stdbuf is used here to ensure we get the output from buffer before it's terminated
-  timeout 5 stdbuf -oL "${redis_cli}" -h "${host}" -p "${port}" --stat -i 0.5 &>> "${LOGFILE}"
+  # stdbuf is used to ensure we get output from buffer before it's terminated
+  timeout 5 stdbuf -oL \
+    "${redis_cli}" -h "${host}" -p "${port}" --stat -i 0.5 &>> "${LOGFILE}"
   print_blankline "${LOGFILE}"
 
   # Tests latency by sending "PING" and waiting for "PONG"
@@ -76,23 +78,28 @@ print_redis_timings() {
 
 print_redis_latency() {
   # Redis 4 changes the output and auto-exits after 1 second (default interval)
-  # Once 3.2 becomes EOL, we can remove the "timeout" and rely entirely on the set "interval"
-  local latency=$( timeout 3 "${redis_cli}" -h "${host}" -p "${port}" --latency -i 2.5 2>&1 )
-  # We have to filter the output for the last occurance (splitting on the ANSI 2K "Clear entire line")
-  # Running "redis-cli --latency | cat -e" would demonstrate the problem this resolves
+  # Once 3.2 is EOL, remove the "timeout" and just use the set "interval"
+  local latency=$( timeout 3 \
+    "${redis_cli}" -h "${host}" -p "${port}" --latency -i 2.5 2>&1 )
+  # We have to filter the output for the last occurrence (splitting on the
+  # ANSI 2K "Clear entire line")
+  # Running "redis-cli --latency | cat -e" would show the problem this resolves
   echo "$( ts ) ${latency##*2K}" >> "${LOGFILE}"
 }
 
 print_redis_cmd() {
   local command="$1"
   echo "Redis ${command}" >> "${LOGFILE}"
-  # The redis-cli client doesn't have built-in connection timeout handling, thus use "timeout"
-  timeout 3 "${redis_cli}" -h "${host}" -p "${port}" ${command} &>> "${LOGFILE}"
+  # The redis-cli client doesn't have built-in connection timeout handling,
+  # thus we must use "timeout" to stop it hanging when we don't get a reply
+  timeout 3 \
+    "${redis_cli}" -h "${host}" -p "${port}" ${command} &>> "${LOGFILE}"
 }
 
 print_redis_cmd_fallback() {
   local command="$1"
   echo "Redis ${command} (via ncat)" >> "${LOGFILE}"
   # Connection timeout of 3 seconds and forcing CRLF for lines
-  ( printf "${command}\r\n"; sleep 1 ) | ncat -w 3 -C "${host}" "${port}" &>> "${LOGFILE}"
+  ( printf "${command}\r\n"; sleep 1 ) | \
+    ncat -w 3 -C "${host}" "${port}" &>> "${LOGFILE}"
 }

--- a/src/plugins/redis
+++ b/src/plugins/redis
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+#   Copyright (C) 2017 Rackspace, Inc.
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program; if not, write to the Free Software Foundation, Inc.,
+#   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#
+
+print_redis() {
+  local LOGFILE="$1"
+  local plugin_name=${FUNCNAME[0]/print_/}
+  local redis_cli=$( type -p redis-cli )
+  local host=${PLUGIN_OPTS_REDIS_HOST:-"127.0.0.1"}
+  local port=${PLUGIN_OPTS_REDIS_PORT:-"6379"}
+  log INFO "Starting '${plugin_name}' report - ${LOGFILE##*/}"
+  print_redis_timings "${LOGFILE}"
+  print_blankline "${LOGFILE}"
+  print_redis_info "${LOGFILE}"
+  log INFO "Ended '${plugin_name}' report"
+}
+
+print_redis_timings() {
+  if [[ -n "${redis_cli}" ]]; then
+    print_blankline "${LOGFILE}"
+
+    echo "Redis stat (+delta / 0.5s)" >> "${LOGFILE}"
+    # "--stat" expects a TTY (does an ioctl with TCGETS), stdbuf resolves this neatly
+    timeout 5 stdbuf -oL "${redis_cli}" -h "${host}" -p "${port}" --stat -i 0.5 &>> "${LOGFILE}"
+    print_blankline "${LOGFILE}"
+
+    # Tests latency by sending "PING" and waiting for "PONG"
+    echo "Redis average latencies (3s)" >> "${LOGFILE}"
+    print_redis_latency "${LOGFILE}"
+    print_redis_latency "${LOGFILE}"
+    print_redis_latency "${LOGFILE}"
+    print_blankline "${LOGFILE}"
+
+    # Tests the client where the command is ran from for system latency
+    echo "Local System Intrinsic Latency (5s)" >> "${LOGFILE}"
+    "${redis_cli}" --intrinsic-latency 5 &>> "${LOGFILE}"
+  fi
+}
+
+print_redis_latency() {
+  local latency=$( timeout 3 "${redis_cli}" -h "${host}" -p "${port}" --latency 2>&1 )
+  # We have to filter the output for the last occurance (splitting on the ANSI "Clear entire line")
+  echo "$( ts ) ${latency##*2K}" >> "${LOGFILE}"
+}
+
+print_redis_info() {
+  echo "Redis INFO ALL" >> "${LOGFILE}"
+  if [[ -n "${redis_cli}" ]]; then
+    "${redis_cli}" -h "${host}" -p "${port}" info all &>> "${LOGFILE}"
+  else
+    ( printf "INFO ALL\r\n"; sleep 1 ) | nc "${host}" "${port}" &>> "${LOGFILE}"
+  fi
+}

--- a/src/plugins/redis
+++ b/src/plugins/redis
@@ -24,46 +24,75 @@ print_redis() {
   local redis_cli=$( type -p redis-cli )
   local host=${PLUGIN_OPTS_REDIS_HOST:-"127.0.0.1"}
   local port=${PLUGIN_OPTS_REDIS_PORT:-"6379"}
+  # Wrap the more time consuming tests behind a default "no" flag
+  local timings=${PLUGIN_OPTS_REDIS_TIMINGS:-"no"}
+  # Wrap the less useful client listing behind a default "no" flag
+  local clients=${PLUGIN_OPTS_REDIS_CLIENTS:-"no"}
+
   log INFO "Starting '${plugin_name}' report - ${LOGFILE##*/}"
-  print_redis_timings "${LOGFILE}"
   print_blankline "${LOGFILE}"
-  print_redis_info "${LOGFILE}"
+  if [[ -n "${redis_cli}" ]]; then
+
+    if [[ "${timings,,}" == "yes" ]]; then
+      print_redis_timings
+      print_blankline "${LOGFILE}"
+    fi
+
+    print_redis_cmd "INFO ALL"
+    print_blankline "${LOGFILE}"
+
+    if [[ "${clients,,}" == "yes" ]]; then
+      print_redis_cmd "CLIENT LIST"
+      print_blankline "${LOGFILE}"
+    fi
+  else
+    # If the redis-cli is unavailable, fallback to ncat
+    print_redis_cmd_fallback "INFO ALL"
+    if [[ "${clients,,}" == "yes" ]]; then
+      print_redis_cmd_fallback "CLIENT LIST"
+    fi
+  fi
   log INFO "Ended '${plugin_name}' report"
 }
 
+# Executing this functions takes ~20 seconds as each command is sampling performance in a timeframe
 print_redis_timings() {
-  if [[ -n "${redis_cli}" ]]; then
-    print_blankline "${LOGFILE}"
+  echo "Redis stat (+delta / 0.5s)" >> "${LOGFILE}"
+  # stdbuf is used here to ensure we get the output from buffer before it's terminated
+  timeout 5 stdbuf -oL "${redis_cli}" -h "${host}" -p "${port}" --stat -i 0.5 &>> "${LOGFILE}"
+  print_blankline "${LOGFILE}"
 
-    echo "Redis stat (+delta / 0.5s)" >> "${LOGFILE}"
-    # "--stat" expects a TTY (does an ioctl with TCGETS), stdbuf resolves this neatly
-    timeout 5 stdbuf -oL "${redis_cli}" -h "${host}" -p "${port}" --stat -i 0.5 &>> "${LOGFILE}"
-    print_blankline "${LOGFILE}"
+  # Tests latency by sending "PING" and waiting for "PONG"
+  echo "Redis average latencies (3s)" >> "${LOGFILE}"
+  print_redis_latency
+  print_redis_latency
+  print_redis_latency
+  print_blankline "${LOGFILE}"
 
-    # Tests latency by sending "PING" and waiting for "PONG"
-    echo "Redis average latencies (3s)" >> "${LOGFILE}"
-    print_redis_latency "${LOGFILE}"
-    print_redis_latency "${LOGFILE}"
-    print_redis_latency "${LOGFILE}"
-    print_blankline "${LOGFILE}"
-
-    # Tests the client where the command is ran from for system latency
-    echo "Local System Intrinsic Latency (5s)" >> "${LOGFILE}"
-    "${redis_cli}" --intrinsic-latency 5 &>> "${LOGFILE}"
-  fi
+  # Tests the client where the command is ran from for system latency
+  echo "Local System Intrinsic Latency (5s)" >> "${LOGFILE}"
+  "${redis_cli}" --intrinsic-latency 5 &>> "${LOGFILE}"
 }
 
 print_redis_latency() {
-  local latency=$( timeout 3 "${redis_cli}" -h "${host}" -p "${port}" --latency 2>&1 )
-  # We have to filter the output for the last occurance (splitting on the ANSI "Clear entire line")
+  # Redis 4 changes the output and auto-exits after 1 second (default interval)
+  # Once 3.2 becomes EOL, we can remove the "timeout" and rely entirely on the set "interval"
+  local latency=$( timeout 3 "${redis_cli}" -h "${host}" -p "${port}" --latency -i 2.5 2>&1 )
+  # We have to filter the output for the last occurance (splitting on the ANSI 2K "Clear entire line")
+  # Running "redis-cli --latency | cat -e" would demonstrate the problem this resolves
   echo "$( ts ) ${latency##*2K}" >> "${LOGFILE}"
 }
 
-print_redis_info() {
-  echo "Redis INFO ALL" >> "${LOGFILE}"
-  if [[ -n "${redis_cli}" ]]; then
-    "${redis_cli}" -h "${host}" -p "${port}" info all &>> "${LOGFILE}"
-  else
-    ( printf "INFO ALL\r\n"; sleep 1 ) | nc "${host}" "${port}" &>> "${LOGFILE}"
-  fi
+print_redis_cmd() {
+  local command="$1"
+  echo "Redis ${command}" >> "${LOGFILE}"
+  # The redis-cli client doesn't have built-in connection timeout handling, thus use "timeout"
+  timeout 3 "${redis_cli}" -h "${host}" -p "${port}" ${command} &>> "${LOGFILE}"
+}
+
+print_redis_cmd_fallback() {
+  local command="$1"
+  echo "Redis ${command} (via ncat)" >> "${LOGFILE}"
+  # Connection timeout of 3 seconds and forcing CRLF for lines
+  ( printf "${command}\r\n"; sleep 1 ) | ncat -w 3 -C "${host}" "${port}" &>> "${LOGFILE}"
 }


### PR DESCRIPTION
If redis-cli is in the PATH, it will:
  * Run `--stat` showing key metric changes over 5 seconds
  * Run `--latency` for 3 seconds, 3 times
  * Run `--intrinsic-latency`, testing the local systems latency
  * Run `info` for general statistics

If the cli tool is not present locally, netcat is used to hit the specified host/port with an `info`.

Both methods support the options:

`PLUGIN_OPTS_REDIS_HOST` defaults to 127.0.0.1
`PLUGIN_OPTS_REDIS_PORT` defaults to 6379

I can re PR this against the `upstream/master` - but it looks like a much larger change until your change https://github.com/rackerlabs/recap/pull/158 is merged. 